### PR TITLE
incorrect arguments to parse_io call

### DIFF
--- a/lib/ltsv.rb
+++ b/lib/ltsv.rb
@@ -28,7 +28,7 @@ module LTSV
     when String
       parse_string(io_or_string, options)
     when IO
-      parse_io(io_or_string = {})
+      parse_io(io_or_string, options)
     end
   end
 
@@ -86,7 +86,7 @@ module LTSV
   private
 
   def parse_io(io, options)#:nodoc:
-    io.map{|l|parse_string l, options}
+    io.map{|l|parse_string l.chomp, options}
   end
 
   def parse_string(string, options)#:nodoc:

--- a/spec/ltsv_spec.rb
+++ b/spec/ltsv_spec.rb
@@ -35,6 +35,16 @@ describe LTSV do
           {:label1 => nil, :label2 => 'value2'}
       end
     end
+
+    context 'IO argment' do
+      it 'can parse labeled tab separated values into file' do
+        LTSV.parse(File.open("#{File.dirname(__FILE__)}/test.ltsv")).should ==
+          [{:label1 => 'value1', :label2 => 'value\\nvalue'},
+           {:label3 => 'value3', :label4 => 'value\\rvalue'},
+           {:label5 => 'value5', :label6 => 'value\\tvalue'},
+           {:label7 => 'value7', :label8 => 'value\\\\value'}] 
+      end
+    end
   end
 
   describe :load do

--- a/spec/test.ltsv
+++ b/spec/test.ltsv
@@ -1,0 +1,4 @@
+label1:value1	label2:value\\nvalue
+label3:value3	label4:value\\rvalue
+label5:value5	label6:value\\tvalue
+label7:value7	label8:value\\\\value


### PR DESCRIPTION
``` ruby
LTSV.parse(File.open('foo.ltsv'))  # to ArgumentError
```
