### PR TITLE
Fix ArgumentError on escaping frozen String

### DIFF
--- a/lib/ltsv.rb
+++ b/lib/ltsv.rb
@@ -133,12 +133,11 @@ module LTSV
   def escape(string)#:nodoc:
     value = string.kind_of?(String) ? string.dup : string.to_s
 
-    value.gsub!("\\", "\\\\")
-    value.gsub!("\n", "\\n")
-    value.gsub!("\r", "\\r")
-    value.gsub!("\t", "\\t")
-
     value
+      .gsub("\\", "\\\\")
+      .gsub("\n", "\\n")
+      .gsub("\r", "\\r")
+      .gsub("\t", "\\t")
   end
 
   module_function :load, :parse, :dump, :parse_io, :parse_string, :parse_line, :unescape!, :escape

--- a/spec/ltsv_spec.rb
+++ b/spec/ltsv_spec.rb
@@ -97,5 +97,15 @@ describe LTSV do
     specify 'fails when object to dump does not respond to :to_hash' do
       lambda{LTSV.dump(Object.new)}.should raise_exception(ArgumentError)
     end
+
+    context 'when given Hash includes a value that returns a frozen String' do
+      let(:hash) do
+        { label: double(to_s: "value".freeze) }
+      end
+
+      it 'does not fail' do
+        LTSV.dump(hash).should == 'label:value'
+      end
+    end
   end
 end


### PR DESCRIPTION
Thank you @condor for creating this great gem! It's very convenient to format our application logs, but I have an idea that it would be even better if it supported frozen String values in its `#dump` implementation.

## Problem

I use ltsv gem to format our chronological logs in our Rails application like this:

```rb
LTSV.dump(foo: "bar", time: Time.current)
```

### Expected behavior

I think it should return a String like `"foo:bar\ttime:2018-11-22 15:10:34 +0900"` without any exception.

### Actual behavior

But unfortunately the code above raises ArgumentError. This is because its implementation  tries to mutate the given String by using `String#gsub!` to escape special characters.

Note: Time.current.to_s (ActiveSupport::TimeWithZone#to_s) returns a frozen String (since Rails 5.2.0), and `LTSV#escape` uses it.

https://github.com/condor/ltsv/blob/f5454500991be53ff1bacaef5d34bc281c1e9ac0/lib/ltsv.rb#L134-L139

- https://github.com/rails/rails/blob/v5.2.0/activesupport/lib/active_support/time_with_zone.rb#L1

## Solution

To fix the problem above, I replaced `String#gsub!` with `String#gsub`.

I want to think there is no special reason to mutate given String here, but I'm afraid there might be a performance reason to choose `String#gsub!`. What do you think @condor?