### PR TITLE
Add missing license

### DIFF
--- a/ltsv.gemspec
+++ b/ltsv.gemspec
@@ -11,6 +11,7 @@ Gem::Specification.new do |gem|
   gem.description   = %q{A Parser / Dumper for LTSV}
   gem.summary       = %q{A Parser / Dumper for LTSV}
   gem.homepage      = "https://github.com/condor/ltsv"
+  gem.licenses      = ["MIT"]
 
   gem.files         = `git ls-files`.split($/)
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }


### PR DESCRIPTION
Set MIT in licenses field

ref. https://guides.rubygems.org/specification-reference/#licenses=